### PR TITLE
update to more recent version of checkout

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
 name: R-CMD-check.yaml
 
@@ -31,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: main
   pull_request:
   workflow_dispatch:
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,3 +27,5 @@ Suggests:
 Depends: 
     R (>= 2.10)
 Config/testthat/edition: 3
+URL: https://github.com/rowlandseymour/speedyBBT
+BugReports: https://github.com/rowlandseymour/speedyBBT/issues


### PR DESCRIPTION
- Update the r-cmd-check GitHub action to match the latest checkout (v6.0)
- Add `workflow_dispatch` trigger for testing
- Action appears to be running now